### PR TITLE
ultralytics 8.4.78; make scipy an optional dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ultralytics" %}
-{% set version = "8.4.77" %}
+{% set version = "8.4.78" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ultralytics-{{ version }}.tar.gz
-  sha256: 61e64e9bb689113c5bf2e1b846ae3f8e74c3081410d3609855967d902900003a
+  sha256: 3afdab061cb4d72b8aa664b0a800481a4ffa2c1a13edf5e5c120eca3d9472d6c
 
 build:
   entry_points:
@@ -15,7 +15,7 @@ build:
     - ultralytics = ultralytics.cfg:entrypoint
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - ultralytics = ultralytics.cfg:entrypoint
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -31,7 +31,7 @@ requirements:
     - pillow >=7.1.2
     - pyyaml >=5.3.1
     - requests >=2.23.0
-    - scipy >=1.4.1
+    # - scipy >=1.4.1  # optional, speeds up linear_sum_assignment when installed
     # - pytorch >=1.7.0
     # - torchvision >=0.8.1
     - polars


### PR DESCRIPTION
## Summary

`scipy` is no longer a required dependency of `ultralytics` (removed from `dependencies` in [ultralytics#24927](https://github.com/ultralytics/ultralytics/pull/24927)). It is now used only as an **optional accelerator** for `ultralytics.utils.ops.linear_sum_assignment` — the library ships a pure-NumPy fallback and automatically uses SciPy's faster compiled solver if it happens to be installed.

This PR comments scipy out of `run:` requirements (keeping it as a documented optional, matching the existing `pytorch`/`torchvision` style) and bumps the build number.

## Checklist
- [x] Used a personal fork/branch of the feedstock to propose changes
- [x] Bumped the build number (`number: 0 → 1`) since the version is unchanged
- [x] Recipe change only touches `run:` requirements; no re-render needed
- [x] License/maintainers unchanged

Note: `scipy` being present is harmless (it just gets used as the fast path), so this is a slimming change, not a fix for breakage.