### PR TITLE
Enable wheel dependency synchronization

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,5 +5,5 @@ conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
 bot:
-  automerge: false
+  automerge: true
   run_deps_from_wheel: true

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,4 +5,5 @@ conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
 bot:
-  automerge: true
+  automerge: false
+  run_deps_from_wheel: true


### PR DESCRIPTION
## Summary

- update existing runtime dependency constraints from each released PyPI wheel
- preserve automatic merging after the existing feedstock checks pass

## Why

Recent version PRs failed because upstream dependency floors changed while the feedstock recipe remained stale. The native conda-forge `run_deps_from_wheel` migrator updates matching active `requirements.run` entries in the bot version PR before the full build, `pip check`, and CLI tests gate automerge.

Dependencies intentionally omitted from the active conda runtime requirements remain reviewable as commented suggestions generated by the bot.

## Validation

- `git diff --check`
- bot configuration validated against the current conda-forge-bot JSON schema
- conda-forge linter passed on the initial head
- independent Claude Code review required on the final head